### PR TITLE
Improve "Nuestra Experiencia" section UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,11 +64,23 @@
       <section id="confianza" class="section section-alt">
         <div class="container">
           <h2 class="section-title">Nuestra Experiencia</h2>
-          <ul class="confidence-list">
-            <li class="fade-up">Más de 10 años protegiendo empresas en LATAM</li>
-            <li class="fade-up" style="animation-delay:0.1s">Partners certificados de AWS y Microsoft</li>
-            <li class="fade-up" style="animation-delay:0.2s">Cumplimiento de normas ISO 27001</li>
-          </ul>
+          <p class="section-intro fade-up">
+            Con más de una década implementando soluciones de seguridad, combinamos certificaciones internacionales y conocimiento local para brindarte un servicio diferencial.
+          </p>
+          <div class="experience-list">
+            <div class="experience-item fade-up">
+              <i class="fas fa-shield-alt"></i>
+              <p><strong>10+ años</strong> protegiendo empresas en LATAM</p>
+            </div>
+            <div class="experience-item fade-up" style="animation-delay:0.1s">
+              <i class="fas fa-award"></i>
+              <p>Partners certificados de <strong>AWS</strong> y <strong>Microsoft</strong></p>
+            </div>
+            <div class="experience-item fade-up" style="animation-delay:0.2s">
+              <i class="fas fa-certificate"></i>
+              <p>Especialistas en cumplimiento <strong>ISO 27001</strong></p>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/styles.css
+++ b/styles.css
@@ -185,6 +185,12 @@ body {
   font-family: "Cinzel", serif;
 }
 
+.section-intro {
+  max-width: 700px;
+  margin: 0 auto 2rem;
+  text-align: center;
+}
+
 .grid-services {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
@@ -246,6 +252,32 @@ body {
 }
 
 .benefit-item:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 0 10px var(--accent-light);
+}
+
+.experience-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.experience-item {
+  background-color: #1b1b1b;
+  padding: 1.5rem;
+  border-radius: 6px;
+  text-align: center;
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.experience-item i {
+  color: var(--gold);
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.experience-item:hover {
   transform: translateY(-5px);
   box-shadow: 0 0 10px var(--accent-light);
 }


### PR DESCRIPTION
## Summary
- revamp `Nuestra Experiencia` with intro paragraph and icons
- add CSS rules for new experience section and intro text

## Testing
- `npm install`
- `npm start` *(server launched on port 3000)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685e82522b808330a97faaac95b16658