### PR TITLE
Improve cyberinsurance UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,11 @@
         <div class="container">
           <!-- Hero section -->
           <div class="cyber-hero">
-            <div class="hero-img" aria-hidden="true"></div>
+            <div class="cyber-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="img" focusable="false">
+                <path d="M12 2l7 4v6c0 5-3.2 9.4-7 10-3.8-.6-7-5-7-10V6l7-4z" />
+              </svg>
+            </div>
             <h2 class="section-title">Protegé tu empresa con Cyberinsurance</h2>
             <p class="section-subtitle">
               Cubrimos las consecuencias financieras de ciberataques para que
@@ -100,7 +104,7 @@
 
           <!-- CTA final -->
           <div class="cyber-cta">
-            <a href="#contacto" class="cta-button">Quiero proteger mi empresa</a>
+            <a href="#contacto" class="cta-button btn-primary">Quiero proteger mi empresa</a>
             <form id="cyberinsurance-form" class="contact-form" autocomplete="off" novalidate>
               <div class="form-group">
                 <label for="cyber-nombre">Nombre</label>

--- a/styles.css
+++ b/styles.css
@@ -881,14 +881,17 @@ body {
 
 /* Cyberinsurance section styles */
 .cyberinsurance-section {
-  background: #000;
-  color: #fff;
+  background: var(--bg-main);
+  color: var(--text);
   padding-top: 3rem;
   padding-bottom: 3rem;
 }
 
 .cyberinsurance-section .section-title {
-  color: #00CED1;
+  color: var(--accent-light);
+}
+.cyberinsurance-section .section-subtitle {
+  color: #d1e8ff;
 }
 
 .cyber-hero {
@@ -896,13 +899,16 @@ body {
   margin-bottom: 2rem;
 }
 
-.cyber-hero .hero-img {
-  width: 100%;
-  max-width: 600px;
-  height: 220px;
-  background: #232b3a;
+.cyber-icon {
+  width: 96px;
+  height: 96px;
   margin: 0 auto 1.5rem;
-  border-radius: 8px;
+}
+.cyber-icon svg {
+  width: 100%;
+  height: 100%;
+  stroke: var(--accent-light);
+  fill: none;
 }
 
 .cyber-benefits {
@@ -918,26 +924,25 @@ body {
   margin: 2rem 0;
   text-align: center;
 }
-
+.cyber-differentials .card-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+@media (min-width: 901px) {
+  .cyber-differentials .card-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
 .cta-button {
-  display: inline-block;
-  background: #00CED1;
-  color: #000;
-  padding: 0.9rem 1.8rem;
-  border-radius: 28px;
-  font-weight: 700;
   text-decoration: none;
-  transition: background 0.3s, transform 0.2s;
   margin-bottom: 2rem;
+  display: inline-block;
 }
-
-.cta-button:hover,
-.cta-button:focus {
-  background: #F5C87A;
-  color: #000;
-  transform: translateY(-2px);
+.cyber-cta .btn-primary {
+  margin-bottom: 1.5rem;
 }
-
+.cyber-cta form {
+  margin-top: 1rem;
+}
 .cyber-cta {
   text-align: center;
   margin-top: 2rem;


### PR DESCRIPTION
## Summary
- restyle Cyberinsurance hero with an inline SVG icon
- align CTA button style with the rest of the site
- arrange differential cards in one row on desktop
- tweak colors and spacing for better hierarchy

## Testing
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_685f385e25d88330b2b39a35aa0206ce