### PR TITLE
Fix header logo and CTA alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,3 @@
     <script src="scripts.js"></script>
   </body>
 </html>
-    <script src="scripts.js"></script>
-  </body>
-</html>

--- a/styles.css
+++ b/styles.css
@@ -99,6 +99,7 @@ body {
   font-size: 1.5rem;
   font-weight: 700;
   text-decoration: none;
+  margin-right: auto;
 }
 
 .nav-toggle {
@@ -623,6 +624,8 @@ body {
   border: none;
   outline: none;
   display: inline-block;
+  margin-left: auto;
+  margin-right: auto;
 }
 .insurance-cta .btn-cta:hover,
 .insurance-cta .btn-cta:focus {
@@ -1087,6 +1090,8 @@ body {
 }
 .cyber-cta .btn-cta {
   margin-bottom: 1.5rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 .cyber-cta {
   text-align: center;


### PR DESCRIPTION
## Summary
- center CTA button for insurance section
- center potential cyberinsurance button
- push navigation items to the right with logo spacing
- remove duplicate closing tags in index.html

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_68606560b6488330a56b7056c64de624